### PR TITLE
fix: Fix OpenAI SSE parser to handle tool_calls in streaming responses

### DIFF
--- a/test/AIApiTracer.Tests/AIApiTracer.Tests.csproj
+++ b/test/AIApiTracer.Tests/AIApiTracer.Tests.csproj
@@ -44,6 +44,9 @@
     <None Update="Resoruces\anthropic-v1-messages_response_streaming.2.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Resoruces\openai-v1-completions_response_streaming.2.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/test/AIApiTracer.Tests/Resoruces/openai-v1-completions_response_streaming.2.txt
+++ b/test/AIApiTracer.Tests/Resoruces/openai-v1-completions_response_streaming.2.txt
@@ -1,0 +1,27 @@
+data: {"id":"chatcmpl-BtAGVZwPwx7hgHZkm74Rzo1UNReX0","object":"chat.completion.chunk","created":1752487199,"model":"gpt-4.1-mini-2025-04-14","service_tier":"default","system_fingerprint":"fp_6f2eabb9a5","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_5J0YQaDfJ2i1oaafAZCyYwfX","type":"function","function":{"name":"get_current_weather","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-BtAGVZwPwx7hgHZkm74Rzo1UNReX0","object":"chat.completion.chunk","created":1752487199,"model":"gpt-4.1-mini-2025-04-14","service_tier":"default","system_fingerprint":"fp_6f2eabb9a5","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-BtAGVZwPwx7hgHZkm74Rzo1UNReX0","object":"chat.completion.chunk","created":1752487199,"model":"gpt-4.1-mini-2025-04-14","service_tier":"default","system_fingerprint":"fp_6f2eabb9a5","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"location"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-BtAGVZwPwx7hgHZkm74Rzo1UNReX0","object":"chat.completion.chunk","created":1752487199,"model":"gpt-4.1-mini-2025-04-14","service_tier":"default","system_fingerprint":"fp_6f2eabb9a5","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-BtAGVZwPwx7hgHZkm74Rzo1UNReX0","object":"chat.completion.chunk","created":1752487199,"model":"gpt-4.1-mini-2025-04-14","service_tier":"default","system_fingerprint":"fp_6f2eabb9a5","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Mont"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-BtAGVZwPwx7hgHZkm74Rzo1UNReX0","object":"chat.completion.chunk","created":1752487199,"model":"gpt-4.1-mini-2025-04-14","service_tier":"default","system_fingerprint":"fp_6f2eabb9a5","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"real"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-BtAGVZwPwx7hgHZkm74Rzo1UNReX0","object":"chat.completion.chunk","created":1752487199,"model":"gpt-4.1-mini-2025-04-14","service_tier":"default","system_fingerprint":"fp_6f2eabb9a5","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-BtAGVZwPwx7hgHZkm74Rzo1UNReX0","object":"chat.completion.chunk","created":1752487199,"model":"gpt-4.1-mini-2025-04-14","service_tier":"default","system_fingerprint":"fp_6f2eabb9a5","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"unit"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-BtAGVZwPwx7hgHZkm74Rzo1UNReX0","object":"chat.completion.chunk","created":1752487199,"model":"gpt-4.1-mini-2025-04-14","service_tier":"default","system_fingerprint":"fp_6f2eabb9a5","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-BtAGVZwPwx7hgHZkm74Rzo1UNReX0","object":"chat.completion.chunk","created":1752487199,"model":"gpt-4.1-mini-2025-04-14","service_tier":"default","system_fingerprint":"fp_6f2eabb9a5","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"metric"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-BtAGVZwPwx7hgHZkm74Rzo1UNReX0","object":"chat.completion.chunk","created":1752487199,"model":"gpt-4.1-mini-2025-04-14","service_tier":"default","system_fingerprint":"fp_6f2eabb9a5","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-BtAGVZwPwx7hgHZkm74Rzo1UNReX0","object":"chat.completion.chunk","created":1752487199,"model":"gpt-4.1-mini-2025-04-14","service_tier":"default","system_fingerprint":"fp_6f2eabb9a5","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null}
+
+data: {"id":"chatcmpl-BtAGVZwPwx7hgHZkm74Rzo1UNReX0","object":"chat.completion.chunk","created":1752487199,"model":"gpt-4.1-mini-2025-04-14","service_tier":"default","system_fingerprint":"fp_6f2eabb9a5","choices":[],"usage":{"prompt_tokens":91,"completion_tokens":20,"total_tokens":111,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+
+data: [DONE]


### PR DESCRIPTION
- Add ToolCallBuilder class to accumulate tool call data across chunks
- Extend ChoiceBuilder to track tool calls by index
- Process tool_calls array in delta objects, handling id, type, function name and arguments
- Update response construction to include tool_calls array with proper structure
- Handle null content when tool_calls are present
- Add test case with new resource file openai-v1-completions_response_streaming.2.txt

🤖 Generated with [Claude Code](https://claude.ai/code)