### PR TITLE
feat: Add Docker multi-platform build support for ARM64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.6.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
@@ -45,6 +49,7 @@ jobs:
         with:
           context: .
           file: src/AIApiTracer/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: ${{ inputs.dry-run != 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/src/AIApiTracer/Dockerfile
+++ b/src/AIApiTracer/Dockerfile
@@ -1,15 +1,28 @@
-# Base image
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
+# Base image with multi-platform support
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
 WORKDIR /app
 EXPOSE 8080
 
-# Build stage
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+# Build stage with multi-platform support
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+ARG TARGETARCH
 WORKDIR /src
 
 # Copy everything
 COPY . ./
-RUN dotnet publish -o /app/publish src/AIApiTracer/AIApiTracer.csproj
+
+# Map Docker platform to .NET RID
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        RID="linux-x64"; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        RID="linux-arm64"; \
+    elif [ "$TARGETARCH" = "arm" ]; then \
+        RID="linux-arm"; \
+    else \
+        echo "Unsupported architecture: $TARGETARCH"; \
+        exit 1; \
+    fi && \
+    dotnet publish -a $TARGETARCH -o /app/publish src/AIApiTracer/AIApiTracer.csproj
 
 # Build runtime image
 FROM base AS runtime


### PR DESCRIPTION
- Update Dockerfile to support multi-platform builds using BUILDPLATFORM and TARGETARCH
- Add QEMU and Docker Buildx setup in GitHub Actions release workflow
- Configure build to produce both linux/amd64 and linux/arm64 images
- Map Docker architecture to .NET RID for proper cross-compilation

🤖 Generated with [Claude Code](https://claude.ai/code)