### PR TITLE
fix: Use TARGETPLATFORM instead of BUILDPLATFORM for multi-arch Docker builds

### DIFF
--- a/src/AIApiTracer/Dockerfile
+++ b/src/AIApiTracer/Dockerfile
@@ -1,5 +1,5 @@
 # Base image with multi-platform support
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
+FROM --platform=$TARGETPLATFORM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
 WORKDIR /app
 EXPOSE 8080
 
@@ -25,7 +25,7 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     dotnet publish -a $TARGETARCH -o /app/publish src/AIApiTracer/AIApiTracer.csproj
 
 # Build runtime image
-FROM base AS runtime
+FROM --platform=$TARGETPLATFORM base AS runtime
 WORKDIR /app
 COPY --from=build /app/publish .
 ENTRYPOINT ["dotnet", "AIApiTracer.dll"]


### PR DESCRIPTION
Changed --platform=$BUILDPLATFORM to --platform=$TARGETPLATFORM in base and runtime stages to ensure ARM64 images are built for the correct target architecture instead of inheriting the AMD64 build platform.

🤖 Generated with [Claude Code](https://claude.ai/code)