### PR TITLE
ci: fix workflows seiton detection

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ on:
     tags:
       - "!*" # not a tag push
     paths-ignore:
-      - '**.md'
+      - "**.md"
       - .github/**
       - docs/**
   pull_request:
@@ -15,7 +15,7 @@ on:
       - main
       - release/**
     paths-ignore:
-      - '**.md'
+      - "**.md"
       - .github/**
       - docs/**
   workflow_dispatch:
@@ -34,7 +34,7 @@ jobs:
 
   publish-executables:
     name: Publish Executables
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' }}
     permissions:
       contents: read
     runs-on: ubuntu-24.04
@@ -46,7 +46,7 @@ jobs:
       - uses: Cysharp/Actions/.github/actions/checkout@main
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
       - name: Publish Executable
-        run:  dotnet publish src/AIApiTracer -r ${{ matrix.rid }} --self-contained -p:PublishSingleFile=true -o ./publish/${{ matrix.rid }}
+        run: dotnet publish src/AIApiTracer -r ${{ matrix.rid }} --self-contained -p:PublishSingleFile=true -o ./publish/${{ matrix.rid }}
       - name: Create ZIP file
         run: |
           cd ./publish/${{ matrix.rid }}
@@ -59,10 +59,10 @@ jobs:
 
   publish-executables-macos:
     name: Publish Executables for macOS
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' }}
     permissions:
       contents: read
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 10
     strategy:
       matrix:
@@ -71,7 +71,7 @@ jobs:
       - uses: Cysharp/Actions/.github/actions/checkout@main
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
       - name: Publish Executable
-        run:  dotnet publish src/AIApiTracer -r ${{ matrix.rid }} --self-contained -p:PublishSingleFile=true -o ./publish/${{ matrix.rid }}
+        run: dotnet publish src/AIApiTracer -r ${{ matrix.rid }} --self-contained -p:PublishSingleFile=true -o ./publish/${{ matrix.rid }}
       - name: Create ZIP file
         run: |
           cd ./publish/${{ matrix.rid }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,11 +67,13 @@ jobs:
       - uses: Cysharp/Actions/.github/actions/checkout@main
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
       - name: Publish Executable
-        run:  dotnet publish src/AIApiTracer -r ${{ matrix.rid }} --self-contained -p:PublishSingleFile=true -p:EnableCompressionInSingleFile=true -o ./publish/${{ matrix.rid }}
+        run: dotnet publish src/AIApiTracer -r ${{ matrix.rid }} --self-contained -p:PublishSingleFile=true -p:EnableCompressionInSingleFile=true -o ./publish/${{ matrix.rid }}
       - name: Create ZIP file
         run: |
           cd ./publish/${{ matrix.rid }}
-          zip -r ../AIApiTracer-${{ matrix.rid }}-${{ inputs.tag }}.zip .
+          zip -r ../AIApiTracer-${{ matrix.rid }}-${TAG}.zip .
+        env:
+          TAG: ${{ inputs.tag }}
       - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: AIApiTracer-${{ matrix.rid }}-${{ inputs.tag }}
@@ -84,16 +86,16 @@ jobs:
       contents: write
     uses: Cysharp/Actions/.github/workflows/create-release.yaml@main
     with:
-      commit-id: ''
+      commit-id: ""
       dry-run: ${{ inputs.dry-run }}
       tag: ${{ inputs.tag }}
-      release-format: '{0}'
+      release-format: "{0}"
       release-upload: true
       release-asset-path: |
-          ./AIApiTracer-win-x64-${{ inputs.tag }}/AIApiTracer-win-x64-${{ inputs.tag }}.zip
-          ./AIApiTracer-win-arm64-${{ inputs.tag }}/AIApiTracer-win-arm64-${{ inputs.tag }}.zip
-          ./AIApiTracer-linux-x64-${{ inputs.tag }}/AIApiTracer-linux-x64-${{ inputs.tag }}.zip
-          ./AIApiTracer-linux-arm64-${{ inputs.tag }}/AIApiTracer-linux-arm64-${{ inputs.tag }}.zip
-          ./AIApiTracer-osx-arm64-${{ inputs.tag }}/AIApiTracer-osx-arm64-${{ inputs.tag }}.zip
+        ./AIApiTracer-win-x64-${{ inputs.tag }}/AIApiTracer-win-x64-${{ inputs.tag }}.zip
+        ./AIApiTracer-win-arm64-${{ inputs.tag }}/AIApiTracer-win-arm64-${{ inputs.tag }}.zip
+        ./AIApiTracer-linux-x64-${{ inputs.tag }}/AIApiTracer-linux-x64-${{ inputs.tag }}.zip
+        ./AIApiTracer-linux-arm64-${{ inputs.tag }}/AIApiTracer-linux-arm64-${{ inputs.tag }}.zip
+        ./AIApiTracer-osx-arm64-${{ inputs.tag }}/AIApiTracer-osx-arm64-${{ inputs.tag }}.zip
       nuget-push: false
     secrets: inherit


### PR DESCRIPTION
## Summary

Fix seiton detection. still detected, however these are known and handled.

**before**

| File         | Errors | Warnings |
|--------------|-------:|---------:|
| build.yaml   |      0 |       11 |
| release.yaml |      2 |        5 |

| Rule                          | Count |
|-------------------------------|------:|
| unpinned-uses                 |    13 |
| if-expr-wrapper               |     2 |
| deny-inherit-secrets          |     1 |
| run-inputs-context-direct-use |     1 |
| runner-no-latest              |     1 |


**after**

1 error, 13 warnings in 2 files

| File         | Errors | Warnings |
|--------------|-------:|---------:|
| build.yaml   |      0 |        8 |
| release.yaml |      1 |        5 |

| Rule                 | Count |
|----------------------|------:|
| unpinned-uses        |    13 |
| deny-inherit-secrets |     1 |